### PR TITLE
Fix areas that are prone to confusion

### DIFF
--- a/tutorials/06_ControlFlow/readme.md
+++ b/tutorials/06_ControlFlow/readme.md
@@ -32,7 +32,7 @@ EVM底层主要是使用跳转指令`JUMP`，`JUMPI`，和`JUMPDEST`进行代码
 #define macro MAIN() = takes (0) returns (0) {
     // 从 calldata 读取值
     0x00 calldataload        // [calldata @ 0x00]
-    0 eq
+    0x00 eq
     jump_one jumpi
 
     // 如果到达此点，则revert


### PR DESCRIPTION
This is a small mistake
The provided code is 0x00, but the document is 0. When reading, it is easy to confuse
